### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-chatwork.gemspec
+++ b/fluent-plugin-chatwork.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd"
+  spec.add_dependency "fluentd", [">= 0.14.15", "< 2"]
   spec.add_dependency "chatwork", ">= 0.4.0"
 
   spec.add_development_dependency "bundler"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ end
 
 require 'fluent/load'
 require 'fluent/test'
+require 'fluent/test/driver/output'
 
 require 'fluent/plugin/out_chatwork'
 


### PR DESCRIPTION
I've tried to migrate to use v0.14 Output Plugin API.
In v0.14, Fluentd users will be able to switch non-buffered/buffered plugin by plugin configure.
Because v0.14 Output Plugin API is integrated in Fluent::Plugin::Output class.
We can choose this behavior with prefer_buffered_processing, process, and write APIs.

This PR contains major update change.
Could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks in advance.